### PR TITLE
1-to-be-able-to-get-a-route-url-by-its-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New third optional parameter `$name` for the methods `addGetRoute()` and `addPostRoute()` to name a route.
+- New method `getRouteUrl("home.index")` to get the URL from a route name.
+
 ## [0.1.3] 2020-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ As this library is using [nikic/fast-route](https://github.com/nikic/FastRoute) 
 - [2. Register a POST route](#2-register-a-post-route)
 - [3. Catching url not found exceptions](#3-catching-url-not-found-exceptions)
 - [4. Catching method not allowed exceptions](#4-catching-method-not-allowed-exceptions)
+- [5. Naming a route](#5-naming-a-route)
+- [6. Get the URL of a named route](#6-get-the-url-of-a-named-route)
 
 ### 1. Register a GET route
 
@@ -130,6 +132,33 @@ try {
     // Display a 405 page...
   }
 }
+```
+
+### 5. Naming a route
+
+In this example, we will name a route.
+
+```php
+use function Folded\addGetRoute;
+
+addGetRoute("/", function() {
+  echo "welcome home";
+}, "home.index");
+```
+
+### 6. Get the URL of a named route
+
+In this example, we will get the name of a named route.
+
+```php
+use function Folded\addGetRoute;
+use function Folded\getRouteUrl;
+
+addGetRoute("/user/{user}/post/{post}", function($user, $post) {
+  echo "User $user posted $post";
+}, "user.post.show");
+
+echo getRouteUrl("user.post.show", ["user" => 42, "post" => 1]); // string(15) "/user/42/post/1"
 ```
 
 ## Version support

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
             "src/getRequestedUrl.php",
             "src/getRequestMethod.php",
             "src/getRoutes.php",
+            "src/getRouteUrl.php",
             "src/matchRequestedUrl.php"
         ]
     }

--- a/src/addGetRoute.php
+++ b/src/addGetRoute.php
@@ -12,6 +12,9 @@ if (!function_exists("addGetRoute")) {
      *
      * @param string  $route  The URL or route pattern.
      * @param Closure $action The function to trigger when the current browsed URL matches.
+     * @param string  $name   The name of the route (optional).
+     *
+     * @throws InvalidArgumentException If the route name is empty.
      *
      * @since 0.1.0
      *
@@ -20,8 +23,8 @@ if (!function_exists("addGetRoute")) {
      *  echo "<h1>Welcome</h1>";
      * });
      */
-    function addGetRoute(string $route, Closure $action): void
+    function addGetRoute(string $route, Closure $action, ?string $name = null): void
     {
-        Router::addGetRoute($route, $action);
+        Router::addGetRoute($route, $action, $name);
     }
 }

--- a/src/addPostRoute.php
+++ b/src/addPostRoute.php
@@ -20,8 +20,8 @@ if (!function_exists("addPostRoute")) {
      *  echo "<h1>Search results for $search</h1>";
      * });
      */
-    function addPostRoute(string $route, Closure $action): void
+    function addPostRoute(string $route, Closure $action, ?string $name = null): void
     {
-        Router::addPostRoute($route, $action);
+        Router::addPostRoute($route, $action, $name);
     }
 }

--- a/src/getRouteUrl.php
+++ b/src/getRouteUrl.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Folded;
+
+if (!function_exists("getRouteUrl")) {
+    /**
+     * Get the URL associated with the given route.
+     * If the route contains placeholders, you need to pass the parameters to be filled.
+     *
+     * @param string $name       The name of the route.
+     * @param array  $parameters The parameters, by key-value pairs or simply values, to fill in the placeholders (optional).
+     *
+     * @throws OurOfRangeException If the route name is not found.
+     *
+     * @since 0.2.0
+     *
+     * @example
+     * Router::getRouteUrl("user.show", ["user" => 42]);
+     */
+    function getRouteUrl(string $name, array $parameters = []): string
+    {
+        return Router::getRouteUrl($name, $parameters);
+    }
+}

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -149,3 +149,87 @@ it("should pass parameters correctly if the URL matches", function (): void {
 
     expect(Router::matchRequestedUrl())->toBe("showing post #42");
 });
+
+it("should get an URL by the route name", function (): void {
+    Router::addGetRoute("/about-us", function (): void {
+    }, "about-us.index");
+
+    expect(Router::getRouteUrl("about-us.index"))->toBe("/about-us");
+});
+
+it("should get an URL by its route name even if it has parameters, and parameters are filled by index", function (): void {
+    Router::addGetRoute("/user/{user}/post/{post}", function (): void {
+    }, "user.post.show");
+
+    expect(Router::getRouteUrl("user.post.show", [1, 42]))->toBe("/user/1/post/42");
+});
+
+it("should get an URL by its route name even if it has parameters, and parameters are filled by key name", function (): void {
+    Router::addGetRoute("/user/{user}/post/{post}", function (): void {
+    }, "user.post.show");
+
+    expect(Router::getRouteUrl("user.post.show", ["user" => 1, "post" => 42]))->toBe("/user/1/post/42");
+});
+
+it("should get an URL by its route name event if it has parameters, and parameters are filled by key name and index", function (): void {
+    Router::addGetRoute("/user/{user}/post/{post}", function (): void {
+    }, "user.post.show");
+
+    expect(Router::getRouteUrl("user.post.show", ["user" => 1, 42]))->toBe("/user/1/post/42");
+});
+
+it("should get the URL of a parameterized POST route", function (): void {
+    Router::addPostRoute("/user/{user}/post", function (): void {
+    }, "user.post.store");
+
+    expect(Router::getRouteUrl("user.post.store", ["user" => 42]))->toBe("/user/42/post");
+});
+
+it("should throw an exception if the route name does not exist", function (): void {
+    $this->expectException(OutOfRangeException::class);
+
+    Router::getRouteUrl("home.index");
+});
+
+it("should throw an exception if the route name is empty", function (): void {
+    $this->expectException(InvalidArgumentException::class);
+
+    Router::addGetRoute("/", function (): void {
+    }, "");
+});
+
+it("should throw an exception if one of the parameter is missing", function (): void {
+    $this->expectException(InvalidArgumentException::class);
+
+    Router::addGetRoute("/user/{user}/post/{post}", function (): void {
+    }, "user.post.show");
+
+    Router::getRouteUrl("user.post.show", ["user" => 42]);
+});
+
+it("should throw an exception message if one of the parameter is missing", function (): void {
+    $this->expectExceptionMessage("parameter post missing for route /user/{user}/post/{post}");
+
+    Router::addGetRoute("/user/{user}/post/{post}", function (): void {
+    }, "user.post.show");
+
+    Router::getRouteUrl("user.post.show", ["user" => 42]);
+});
+
+it("should throw an exception if the parameter does not match the regexp", function (): void {
+    $this->expectException(InvalidArgumentException::class);
+
+    Router::addGetRoute("/user/{user}", function (): void {
+    }, "user.show");
+
+    Router::getRouteUrl("user.show", ["/42"]);
+});
+
+it("should throw an exception message if the parameter does not match the regexp", function (): void {
+    $this->expectExceptionMessage("parameter user does not matches regular expression [^/]+ for route /user/{user}");
+
+    Router::addGetRoute("/user/{user}", function (): void {
+    }, "user.show");
+
+    echo Router::getRouteUrl("user.show", ["/42"]);
+});

--- a/tests/getRouteUrlTest.php
+++ b/tests/getRouteUrlTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+use function Folded\getRouteUrl;
+use function Folded\addGetRoute;
+
+it("should get the URL of the parameterized route", function (): void {
+    addGetRoute("/user/{user}", function (): void {
+    }, "user.show");
+
+    expect(getRouteUrl("user.show", ["user" => 42]))->toBe("/user/42");
+});


### PR DESCRIPTION
## Added

- New third optional parameter `$name` for methods `addGetRoute()` and `addPostRoute()`.
- New method `getRouteUrl()` to get the URL of a named route.

## Fixed

None.

## Breaking

None.