### PR TITLE
use-route-not-found-exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- The function `redirectToRoute()` will now throw a `Folded\Exceptions\RouteNotFoundException` instead of a `OutOfRangeException` in case the route is not found.
+
 ## [0.3.0] 2020-09-15
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.4.0",
         "nikic/fast-route": "1.*",
-        "folded/exception": "0.1.*",
+        "folded/exception": "0.2.*",
         "folded/http": "0.1.*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9989180cd89f84a3904e8e9ed9adedea",
+    "content-hash": "3691c8b2000c85d88d0b653047461c13",
     "packages": [
         {
             "name": "folded/exception",
-            "version": "v0.1.0",
+            "version": "v0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/folded-php/exception.git",
-                "reference": "5e61ee7cf27bdf4e35329aec3bfa4d8ae7ce3612"
+                "reference": "86feb672859741e556080c308b4f3340941b1c62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/folded-php/exception/zipball/5e61ee7cf27bdf4e35329aec3bfa4d8ae7ce3612",
-                "reference": "5e61ee7cf27bdf4e35329aec3bfa4d8ae7ce3612",
+                "url": "https://api.github.com/repos/folded-php/exception/zipball/86feb672859741e556080c308b4f3340941b1c62",
+                "reference": "86feb672859741e556080c308b4f3340941b1c62",
                 "shasum": ""
             },
             "require": {
@@ -45,7 +45,7 @@
                 }
             ],
             "description": "Various kind of exception to throw for your web app.",
-            "time": "2020-09-06T20:46:52+00:00"
+            "time": "2020-09-15T19:18:48+00:00"
         },
         {
             "name": "folded/http",
@@ -142,16 +142,16 @@
     "packages-dev": [
         {
             "name": "composer/semver",
-            "version": "1.5.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de"
+                "reference": "114f819054a2ea7db03287f5efb757e2af6e4079"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
-                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "url": "https://api.github.com/repos/composer/semver/zipball/114f819054a2ea7db03287f5efb757e2af6e4079",
+                "reference": "114f819054a2ea7db03287f5efb757e2af6e4079",
                 "shasum": ""
             },
             "require": {
@@ -199,7 +199,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2020-01-13T12:06:48+00:00"
+            "time": "2020-09-09T09:34:06+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -851,16 +851,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v0.3.1",
+            "version": "v0.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "c6ba469e686db775451a4731ef9af6d275fbeaad"
+                "reference": "be7fe41179262fd91491856845b4b41c939099ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/c6ba469e686db775451a4731ef9af6d275fbeaad",
-                "reference": "c6ba469e686db775451a4731ef9af6d275fbeaad",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/be7fe41179262fd91491856845b4b41c939099ab",
+                "reference": "be7fe41179262fd91491856845b4b41c939099ab",
                 "shasum": ""
             },
             "require": {
@@ -869,7 +869,7 @@
                 "pestphp/pest-plugin-coverage": "^0.3",
                 "pestphp/pest-plugin-init": "^0.3",
                 "php": "^7.3 || ^8.0",
-                "phpunit/phpunit": "9.3.7 || 9.3.8"
+                "phpunit/phpunit": "9.3.7 || 9.3.8 || 9.3.9 || 9.3.10"
             },
             "require-dev": {
                 "illuminate/console": "^7.16.1",
@@ -924,7 +924,7 @@
                 "testing",
                 "unit"
             ],
-            "time": "2020-08-29T21:55:28+00:00"
+            "time": "2020-09-13T13:16:38+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -1463,16 +1463,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.1.7",
+            "version": "9.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2ef92bec3186a827faf7362ff92ae4e8ec2e49d2"
+                "reference": "cf6582906d4b2502c5f4c6be6a3d0b4cd5b3ef7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2ef92bec3186a827faf7362ff92ae4e8ec2e49d2",
-                "reference": "2ef92bec3186a827faf7362ff92ae4e8ec2e49d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/cf6582906d4b2502c5f4c6be6a3d0b4cd5b3ef7f",
+                "reference": "cf6582906d4b2502c5f4c6be6a3d0b4cd5b3ef7f",
                 "shasum": ""
             },
             "require": {
@@ -1480,7 +1480,7 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.8",
-                "php": "^7.3 || ^8.0",
+                "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
                 "sebastian/code-unit-reverse-lookup": "^2.0.2",
@@ -1526,7 +1526,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-09-03T07:09:19+00:00"
+            "time": "2020-09-15T06:14:11+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1731,16 +1731,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.3.8",
+            "version": "9.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "93d78d8e2a06393a0d0c1ead6fe9984f1af1f88c"
+                "reference": "919333f2d046a89f9238f15d09f17a8f0baa5cc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/93d78d8e2a06393a0d0c1ead6fe9984f1af1f88c",
-                "reference": "93d78d8e2a06393a0d0c1ead6fe9984f1af1f88c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/919333f2d046a89f9238f15d09f17a8f0baa5cc2",
+                "reference": "919333f2d046a89f9238f15d09f17a8f0baa5cc2",
                 "shasum": ""
             },
             "require": {
@@ -1754,7 +1754,7 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.1",
                 "phar-io/version": "^3.0.2",
-                "php": "^7.3 || ^8.0",
+                "php": ">=7.3",
                 "phpspec/prophecy": "^1.11.1",
                 "phpunit/php-code-coverage": "^9.1.5",
                 "phpunit/php-file-iterator": "^3.0.4",
@@ -1816,7 +1816,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-08-27T06:30:58+00:00"
+            "time": "2020-09-12T09:34:39+00:00"
         },
         {
             "name": "psr/container",
@@ -2845,16 +2845,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14"
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5e20b83385a77593259c9f8beb2c43cd03b2ac14",
-                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
                 "shasum": ""
             },
             "require": {
@@ -2863,7 +2863,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2891,7 +2891,7 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
-            "time": "2020-06-06T08:49:21+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2967,16 +2967,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b"
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
-                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ba7d54483095a198fa51781bc608d17e84dffa2",
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2",
                 "shasum": ""
             },
             "require": {
@@ -2989,7 +2989,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3025,7 +3025,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -3740,16 +3740,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442"
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/58c7475e5457c5492c26cc740cc0ad7464be9442",
-                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
                 "shasum": ""
             },
             "require": {
@@ -3762,7 +3762,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3798,7 +3798,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/src/Router.php
+++ b/src/Router.php
@@ -15,6 +15,7 @@ use function Foled\getRequestedUri;
 use function FastRoute\simpleDispatcher;
 use Folded\Exceptions\UrlNotFoundException;
 use Folded\Exceptions\MethodNotAllowedException;
+use Folded\Exceptions\RouteNotFoundException;
 
 /**
  * Represent the engine that matches the current browsed URL against registered URLs.
@@ -178,7 +179,7 @@ class Router
      * @param string $name   The name of the route.
      * @param int    $status The HTTP status code to use when redirecting (default: 303 - See other).
      *
-     * @throws OutOfRangeException If the route name is not found.
+     * @throws RouteNotFoundException If the route name is not found.
      *
      * @since 0.3.0
      *
@@ -189,9 +190,8 @@ class Router
      */
     public static function redirectToRoute(string $name, int $status = Redirection::SEE_OTHER): void
     {
-        // @todo Use Folded\RouteNotFoundException instead.
         if (!self::hasRoute($name)) {
-            throw new OutOfRangeException("route $name not found");
+            throw (new RouteNotFoundException("route $name not found"))->setRoute($name);
         }
 
         $url = self::getRouteUrl($name);

--- a/src/redirectToRoute.php
+++ b/src/redirectToRoute.php
@@ -13,7 +13,7 @@ if (!function_exists("redirectToRoute")) {
      * @param string $name   The name of the route.
      * @param int    $status The HTTP status code to use when redirecting (default: 303 - See other).
      *
-     * @throws OutOfRangeException If the route name is not found.
+     * @throws RouteNotFoundException If the route name is not found.
      *
      * @since 0.3.0
      *

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 use Folded\Router;
 use Folded\Exceptions\UrlNotFoundException;
+use Folded\Exceptions\RouteNotFoundException;
 use Folded\Exceptions\MethodNotAllowedException;
 
 beforeEach(function (): void {
@@ -235,9 +236,25 @@ it("should throw an exception message if the parameter does not match the regexp
 });
 
 it("should raise an exception if the route name is not found", function (): void {
-    $this->expectException(OutOfRangeException::class);
+    $this->expectException(RouteNotFoundException::class);
 
     Router::redirectToRoute("home.index");
+});
+
+it("should raise an exception message if the route name is not found", function (): void {
+    $this->expectExceptionMessage("route home.index not found");
+
+    Router::redirectToRoute("home.index");
+});
+
+it("should set the route in the exception if the route name is not found", function (): void {
+    $route = "home.index";
+
+    try {
+        Router::redirectToRoute($route);
+    } catch (RouteNotFoundException $exception) {
+        expect($exception->getRoute())->toBe($route);
+    }
 });
 
 it("should return null when redirecting to a route", function (): void {


### PR DESCRIPTION
## Added

None.

## Fixed

None.

## Breaking

- Throwing `Folded\Exceptions\RouteNotFoundException` instead of `OutOfRangeException` when calling `redirectToRoute()` with a route name that have not been registered yet.