### PR TITLE
17-missing-namespace-in-function-exists-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added missing namespace `Folded` in `function_exists` statements.
+
 ## [0.5.0] 2020-09-23
 
 ### Added

--- a/src/addGetRoute.php
+++ b/src/addGetRoute.php
@@ -6,7 +6,7 @@ namespace Folded;
 
 use Closure;
 
-if (!function_exists("addGetRoute")) {
+if (!function_exists("Folded\addGetRoute")) {
     /**
      * Add a GET route.
      *

--- a/src/addPostRoute.php
+++ b/src/addPostRoute.php
@@ -6,7 +6,7 @@ namespace Folded;
 
 use Closure;
 
-if (!function_exists("addPostRoute")) {
+if (!function_exists("Folded\addPostRoute")) {
     /**
      * Add a POST route.
      *

--- a/src/currentRouteIs.php
+++ b/src/currentRouteIs.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("currentRouteIs")) {
+if (!function_exists("Folded\currentRouteIs")) {
     /**
      * Returns true if route matches the current URL, else returns false.
      *

--- a/src/currentUrlIs.php
+++ b/src/currentUrlIs.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("currentUrlIs")) {
+if (!function_exists("Folded\currentUrlIs")) {
     /**
      * Returns true if the URL matches the current URL, else returns false.
      *

--- a/src/getRequestMethod.php
+++ b/src/getRequestMethod.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getRequestedMethod")) {
+if (!function_exists("Folded\getRequestedMethod")) {
     /**
      * Get the requested HTTP protocol.
      *

--- a/src/getRequestedUri.php
+++ b/src/getRequestedUri.php
@@ -6,7 +6,7 @@ namespace Foled;
 
 use function Folded\getRequestedUrl;
 
-if (!function_exists("getRequestedUri")) {
+if (!function_exists("Folded\getRequestedUri")) {
     /**
      * Get the requested URI.
      *

--- a/src/getRequestedUrl.php
+++ b/src/getRequestedUrl.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getRequestedUrl")) {
+if (!function_exists("Folded\getRequestedUrl")) {
     /**
      * Get the requested URL.
      *

--- a/src/getRouteUrl.php
+++ b/src/getRouteUrl.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getRouteUrl")) {
+if (!function_exists("Folded\getRouteUrl")) {
     /**
      * Get the URL associated with the given route.
      * If the route contains placeholders, you need to pass the parameters to be filled.

--- a/src/getRoutes.php
+++ b/src/getRoutes.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getRoutes")) {
+if (!function_exists("Folded\getRoutes")) {
     /**
      * Returns the registered routes.
      *

--- a/src/matchRequestedUrl.php
+++ b/src/matchRequestedUrl.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("matchRequestedUrl")) {
+if (!function_exists("Folded\matchRequestedUrl")) {
     /**
      * Register route and try to match the current browsed URL.
      *

--- a/src/redirectToRoute.php
+++ b/src/redirectToRoute.php
@@ -6,7 +6,7 @@ namespace Folded;
 
 use Http\Redirection;
 
-if (!function_exists("redirectToRoute")) {
+if (!function_exists("Folded\redirectToRoute")) {
     /**
      * Redirects to the URL found by its route name.
      *

--- a/src/redirectToUrl.php
+++ b/src/redirectToUrl.php
@@ -6,7 +6,7 @@ namespace Folded;
 
 use Http\Redirection;
 
-if (!function_exists("redirectToUrl")) {
+if (!function_exists("Folded\redirectToUrl")) {
     /**
      * Redirects to a given URL.
      *


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when namespace `Folded` was missing from `function_exists` statements.

## Breaking

None.