### PR TITLE
12-bug-when-current-route-is-fails-when-query-strings-are-in-the-route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Calling `currentRouteIs()` will now return true even if the current URL has query strings.
+
 ## [0.5.1] 2020-10-01
 
 ### Fixed

--- a/src/Router.php
+++ b/src/Router.php
@@ -136,7 +136,7 @@ class Router
             throw (new RouteNotFoundException("route $route not found"))->setRoute($route);
         }
 
-        return self::getRouteUrl($route, $parameters) === $_SERVER["REQUEST_URI"];
+        return self::getRouteUrl($route, $parameters) === parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -278,6 +278,15 @@ it("should return true if the current route matches the current URL", function (
     expect(Router::currentRouteIs("home.index"))->toBeTrue();
 });
 
+it("should return true even if the current route contains query string", function (): void {
+    $_SERVER["REQUEST_URI"] = "/?utm_source=slack";
+
+    Router::addGetRoute("/", function (): void {
+    }, "home.index");
+
+    expect(Router::currentRouteIs("home.index"))->toBeTrue();
+});
+
 it("should return false if the current route does not matches the current URL", function (): void {
     $_SERVER["REQUEST_URI"] = "/";
 


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when calling `currentRouteIs()` would return false if the current URL was the equivalent one but contained query strings.

## Breaking

None.