### PR TITLE
21-set-the-url-when-throwing-a-method-not-allowed-exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New method `MethodNotAllowed::getUrl()` to be able to catch the URL when a 405 exception is catched when using `matchRequestedUrl()`.
+
 ### Fixed
 
 - Calling `currentRouteIs()` will now return true even if the current URL has query strings.

--- a/src/Router.php
+++ b/src/Router.php
@@ -360,7 +360,7 @@ class Router
             case Dispatcher::METHOD_NOT_ALLOWED:
                 $allowedMethods = $routeInfo[1];
 
-                throw (new MethodNotAllowedException("method not allowed"))->setMethodNotAllowed($requestMethod)->setAllowedMethods($allowedMethods);
+                throw (new MethodNotAllowedException("method not allowed"))->setMethodNotAllowed($requestMethod)->setAllowedMethods($allowedMethods)->setUrl($uri);
             case Dispatcher::FOUND:
                 $handler = $routeInfo[1];
                 $vars = $routeInfo[2];

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -93,6 +93,23 @@ it("should set the allowed methods in the exception if the current URL method is
     }
 });
 
+it("should set the url in the exception if the current URL method is not allowed", function (): void {
+    $url = "/";
+    $_SERVER["REQUEST_URI"] = $url;
+    $_SERVER["REQUEST_METHOD"] = "POST";
+
+    Router::addGetRoute($url, function (): void {
+        echo "hello world";
+    });
+    Router::startEngine();
+
+    try {
+        Router::matchRequestedUrl();
+    } catch (MethodNotAllowedException $exception) {
+        expect($exception->getUrl())->toBe($url);
+    }
+});
+
 it("should execute the closure if the current URL matches the registered route", function (): void {
     $_SERVER["REQUEST_URI"] = "/";
     $_SERVER["REQUEST_METHOD"] = "GET";


### PR DESCRIPTION
## Added

- New method `MethodNowAllowed::getUrl()` in this exception to catch the URL.

## Fixed

None.

## Breaking

None.